### PR TITLE
Fix, sending contrib and pay info to UI

### DIFF
--- a/model_buyer/resources/models_resource.py
+++ b/model_buyer/resources/models_resource.py
@@ -30,10 +30,12 @@ requirements = api.model(name='Requirements', model={
     'data_requirements': fields.Nested(data_requirements, required=True, description='Data requirements')
 })
 
-partial_MSE = api.model(name='Partial MSE Metrics', model={
+contribs = api.model(name='Partial MSE Metrics', model={
     'data_owner': fields.String(required=True,
                                 description='The data owner removed from the training of this model to obtain the partial MSE'),
     'partial_MSE': fields.Float(required=True, description='The MSE of model updated without the data owner'),
+    'payment': fields.Float(required=True, description="The payment for each data owner"),
+    'contributions': fields.Float(required=True, description="Wich percentage of the total of work was done by each data oner")
 })
 
 
@@ -46,7 +48,7 @@ mse_history = api.model(name='MSE History', model={
 metrics = api.model(name='Metrics', model={
     'initial_mse': fields.Float(required=True, description='The Initial MSE of the model'),
     'mse': fields.Float(required=True, description='The MSE of the model'),
-    'partial_MSEs': fields.List(fields.Nested(partial_MSE), required=True, description='The MSE of models updated without one local trainer each'),
+    'partial_MSEs': fields.List(fields.Nested(contribs), required=True, description='The MSE of models updated without one local trainer each'),
     'iterations': fields.Integer(required=True, description='Number of iterations'),
     'improvement': fields.Fixed(required=True, decimals=5, description='The model improvement'),
     'mse_history': fields.List(fields.Nested(mse_history), required=True, description='The model mse history list')

--- a/model_buyer/services/entities/model_response.py
+++ b/model_buyer/services/entities/model_response.py
@@ -1,10 +1,22 @@
 class ModelResponse:
 
     @staticmethod
-    def map_partial_mse(partial_mse):
+    def map_partial_mse(partial_mse, contribs, total_spent, improvement):
         if not partial_mse:
             return []
-        return [dict(data_owner=do_id, partial_MSE=p_mse) for do_id, p_mse in partial_mse.items()]
+        # TODO: Update payment hardcoded
+        p_mse_map = []
+        for do_id, p_mse in partial_mse.items():
+            contrib = round(contribs[do_id] * 100.0, 2)
+            payment = round(float(total_spent) * improvement * contribs[do_id], 2)
+            p_mse_r = round(p_mse, 2)
+            p_mse_map.append({
+                'data_owner': do_id,
+                'partial_MSE': p_mse_r,
+                'contributions': contrib,
+                'payment': payment
+            })
+        return p_mse_map
 
     @staticmethod
     def map_weights(weights):
@@ -20,9 +32,10 @@ class ModelResponse:
                       "user_id": model.user_id,
                       "name": model.name}
 
+        total_spent = 500  # TODO: SE CALCULA A PARTIR DEL IMPROVEMENT, TOTAL_SPENT = TOTAL * IMPROVEMENT
         self.metrics = {"mse": model.mse,
                         "improvement": model.improvement,
-                        "partial_MSEs": self.map_partial_mse(model.partial_MSEs),
+                        "partial_MSEs": self.map_partial_mse(model.partial_MSEs, model.contributions, total_spent, model.improvement),
                         "initial_mse": model.initial_mse,
                         'iterations': model.iterations,
                         'mse_history': model.mse_history


### PR DESCRIPTION
Previously, the model buyer was not sending the data of contributions or payment to the UI.
This PR contains the changes needed to send these metrics to the UI. 

This PR need to be merge along side with [this one from the UI](https://github.com/DeltaML/model-buyer-ui/pull/16).

![Captura de pantalla_2019-10-09_16-35-27](https://user-images.githubusercontent.com/8533854/66514328-476ecc80-eab3-11e9-8512-5538ea732e45.png)
![Captura de pantalla_2019-10-09_16-36-38](https://user-images.githubusercontent.com/8533854/66514355-52296180-eab3-11e9-8639-efc34c0c09be.png)
